### PR TITLE
Added component to embed YT videos #1

### DIFF
--- a/src/components/YoutubeEmbed.tsx
+++ b/src/components/YoutubeEmbed.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-const YoutubeEmbed = ({ src, width = 720, height = 405, className}) => {
+const YoutubeEmbed = ({src, width, height, className}:
+                          {src: string, width: number, height: number, className?: string}) => {
     return (
             <iframe
                 src={src}

--- a/src/components/YoutubeEmbed.tsx
+++ b/src/components/YoutubeEmbed.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+const YoutubeEmbed = ({ src, width = 720, height = 405, className}) => {
+    return (
+            <iframe
+                src={src}
+                width={width}
+                height={height}
+                className={className}
+                allowFullScreen
+            ></iframe>
+    );
+};
+
+export default YoutubeEmbed;


### PR DESCRIPTION
Created a component to embed YouTube videos with a default 16:9 ratio of 720x405 unless otherwise specified.